### PR TITLE
VNDLY-25190 Replace django.utils.six with six

### DIFF
--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -35,10 +35,11 @@ try:
     from django.utils.encoding import force_text
 except ImportError:
     from django.utils.text import force_text
-from django.utils.six.moves.urllib.parse import urlparse, parse_qs
 
 from saml2.config import SPConfig
 from saml2.s_utils import decode_base64_and_inflate, deflate_and_base64_encode
+
+from six.moves.urllib.parse import urlparse, parse_qs
 
 from djangosaml2 import views
 from djangosaml2.cache import OutstandingQueriesCache

--- a/djangosaml2/views.py
+++ b/djangosaml2/views.py
@@ -32,7 +32,6 @@ from django.http import HttpResponseServerError  # 50x
 from django.views.decorators.http import require_POST
 from django.shortcuts import render
 from django.template import TemplateDoesNotExist
-from django.utils.six import text_type, binary_type, PY3
 from django.views.decorators.csrf import csrf_exempt
 
 from saml2 import BINDING_HTTP_REDIRECT, BINDING_HTTP_POST
@@ -46,6 +45,8 @@ from saml2.response import (
 )
 from saml2.validate import ResponseLifetimeExceed, ToEarly
 from saml2.xmldsig import SIG_RSA_SHA1, SIG_RSA_SHA256  # support for SHA1 is required by spec
+
+from six import text_type, binary_type, PY3
 
 from djangosaml2.cache import IdentityCache, OutstandingQueriesCache
 from djangosaml2.cache import StateCache

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='djangosaml2',
-    version='0.17.2',
+    version='0.17.3',
     description='pysaml2 integration for Django',
     long_description='\n\n'.join([read('README.rst'), read('CHANGES')]),
     classifiers=[
@@ -71,6 +71,7 @@ setup(
         'defusedxml>=0.4.1',
         'Django>=1.8',
         'pysaml2>=4.6.0',
+        'six>=1.13.0',
         ],
     extras_require=extra,
     )


### PR DESCRIPTION
This PR adds an external dependency on `six` and updates imports from `django.utils.six`. I'm doing this for now, instead to removing the dependency on `six` entirely, until we have a better way to test this package (e.g., against an Active Directory IdP).

I'm being a little more cautious in this attempt, because I made a silly mistake [the last time I attempted this](https://github.com/vndly-oss/djangosaml2/pull/1), and used the wrong base branch for the PR. This effectively undid all AD-related enhancements made in the `httppost_sha256` branch (which we're [pinned to in vndly](https://github.com/vndly-oss/vndly/blob/0ca35703dd64d7cb067ac74706aa3dbcb010ab1c/requirements/base.txt#L179)), and broke SSO for a number of customers using AD as their IdP.